### PR TITLE
Update loading and error screens, fix MacOS minimised client reactivation

### DIFF
--- a/main.js
+++ b/main.js
@@ -106,8 +106,8 @@ function createLoadingScreen(){
   
   loadingScreen = new BrowserWindow({
       /// define width and height for the mainWindow
-      width: 200,
-      height: 300,
+      width: 400,
+      height: 225,
       /// remove the mainWindow frame, so it will become a frameless mainWindow
       frame: false,
       /// and set the transparency, to remove any mainWindow background color

--- a/main.js
+++ b/main.js
@@ -238,6 +238,9 @@ function createWindow () {
   registerKeys()
   Menu.setApplicationMenu(createMenu());
   mainWindow.loadURL('https://play.frozentundra.me/client/');
+  mainWindow.on('closed', () => {
+      mainWindow = null;
+  })
   
 }
 

--- a/main.js
+++ b/main.js
@@ -130,18 +130,21 @@ function createLoadingScreen(){
 	})
     mainWindow.webContents.on('did-navigate', (_event, _url, httpResponseCode) => {
             if (httpResponseCode >= 400) {
-                createErrorScreen();
+                createErrorScreen(httpResponseCode);
             } 
         })
   });
 };
 let errorScreen;
-function createErrorScreen() {
+function createErrorScreen(code) {
     errorScreen = new BrowserWindow({
         width: 800,
         height: 450,
         frame: false,
-        transparent: true
+        transparent: true,
+        webPreferences: {
+            preload: path.join(__dirname, './preload.js')
+        }
     });
     if (mainWindow) mainWindow.close()
     if (loadingScreen) loadingScreen.close()
@@ -149,6 +152,9 @@ function createErrorScreen() {
     errorScreen.loadURL(
         'file://' + __dirname + '/window/error.html'
     );
+    errorScreen.webContents.on('did-finish-load', () => {
+        errorScreen.webContents.send('httpCode', String(code));
+    })
     errorScreen.on('closed', () => {
         errorScreen = null
     });

--- a/main.js
+++ b/main.js
@@ -24,7 +24,7 @@
 /**
  * Modules and variables
  */
-const {app, dialog, BrowserWindow, Menu, MenuItem, ipcMain, nativeTheme, globalShortcut, session} = require('electron')
+const {app, dialog, BrowserWindow, Menu, MenuItem, ipcMain, nativeTheme, globalShortcut, Notification} = require('electron')
 const path = require('path')
 
 const {autoUpdater} = require("electron-updater");
@@ -296,6 +296,30 @@ function registerKeys() {
 	globalShortcut.register('CmdOrCtrl+Shift+I', () => {
 		mainWindow.webContents.openDevTools();
 	})
+    if (process.platform == 'darwin') {
+        let firstCmdQClickTime = new Date() - 3000;
+        let clickTimeout;
+        let isFirstClickThisSession = true;
+        globalShortcut.register('CmdOrCtrl+Q', () => {
+            // Exit if Cmd+Q pressed twice in 3 seconds
+            if (clickTimeout) {
+                clearTimeout(clickTimeout);
+            }
+            if ((new Date() - firstCmdQClickTime) < 3000) {
+               app.exit();
+            } else {
+                firstCmdQClickTime = new Date();
+                if (isFirstClickThisSession) {
+                    clickTimeout = setTimeout(() => {
+                        new Notification({
+                            body: 'Press Cmd+Q twice to close the client'
+                        }).show();
+                    }, 3000)
+                }
+            }
+            isFirstClickThisSession = false;
+        })
+    }
 }
 /**
  * Toggles Dark mode

--- a/preload.js
+++ b/preload.js
@@ -39,6 +39,10 @@ ipcRenderer.on('reload', async (event) => {
 	
 });
 
+ipcRenderer.on('httpCode', (event, code) => {
+	document.getElementById('notice').innerText += code;
+})
+
 window.addEventListener('load', (event) => {
 	const game = document.getElementById('game');
 	checkExist = setInterval(() => {

--- a/preload.js
+++ b/preload.js
@@ -53,7 +53,8 @@ function load(){
 		localStorage.muted = false;
 		localStorage.theme = 'dark';
 	}
-	ipcRenderer.sendSync('load:data', localStorage.muted, localStorage.theme)
+	// sendSync broke the reopen on macOS for some reason
+	ipcRenderer.send('load:data', localStorage.muted, localStorage.theme)
 }
 function loadSettings() { 
 	const game = document.getElementById('game');

--- a/window/error.html
+++ b/window/error.html
@@ -30,8 +30,9 @@
 </head>
 <body>
     <div class="wrapper">
-        <div>There was an error connecting to game servers <br> Try again later or contact us on Discord</div>
+        <div id="notice">There was an error connecting to game servers <br> Try again later or contact us on Discord<br>Error code:&nbsp;</div>
     </div>
-
+    <script>
+    </script>
 </body>
 </html>

--- a/window/error.html
+++ b/window/error.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="preconnect" href="https://fonts.gstatic.com"> 
+    <link href="https://fonts.googleapis.com/css2?family=Baloo+Tammudu+2&amp;display=swap" rel="stylesheet">
+    <style>
+        .wrapper {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            display: flex;
+            align-content: center;
+            justify-content: center;
+            align-items: center;
+            justify-items: center;
+            box-sizing: border-box;
+            background-color: #2596be;
+            font-family: 'Baloo Tammudu 2', cursive;
+            color: white;
+            font-size: 200%;
+            text-align: center;
+        }
+    </style>
+    <title>Error</title>
+</head>
+<body>
+    <div class="wrapper">
+        <div>There was an error connecting to game servers <br> Try again later or contact us on Discord</div>
+    </div>
+
+</body>
+</html>

--- a/window/loading.html
+++ b/window/loading.html
@@ -21,62 +21,72 @@
 
 
 <!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="UTF-8" />
-    <title>Coastal Freeze</title>
-    <style>
-      /* Define the main wrapper style */
-      .LoaderWrapper {
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Loading</title>
+  <style>
+    .wrapper {
         position: absolute;
         top: 0;
         left: 0;
-
         width: 100%;
         height: 100%;
-
         display: flex;
         align-content: center;
         justify-content: center;
         align-items: center;
         justify-items: center;
-
         box-sizing: border-box;
-        background-color: black;
-      }
-
-      .LoaderContent {
-        color: white;
-		font-family: Arial;
-      }
-		.loader {
-		  border: 5px solid #f3f3f3; /* Light grey */
-		  border-top: 5px solid #3498db; /* Blue */
-		  border-radius: 50%;
-		  width: 50px;
-		  height: 50px;
-		  animation: spin 2s linear infinite;
-		  display: block;
-		}
-		@keyframes spin {
-		  0% { transform: rotate(0deg); }
-		  100% { transform: rotate(360deg); }
-		}
-	  
-    </style>
-  </head>
-  <body>
-	
-    <div class="LoaderWrapper">
-      <div class="LoaderContent">
-		<div class="loader"></div>
-        Loading...
-      </div>
+        background-color: #2596be;
+    }
+    .lds-ring {
+        display: inline-block;
+        position: relative;
+        width: 80px;
+        height: 80px;
+    }
+    .lds-ring div {
+        box-sizing: border-box;
+        display: block;
+        position: absolute;
+        width: 64px;
+        height: 64px;
+        margin: 8px;
+        border: 8px solid #fff;
+        border-radius: 50%;
+        animation: lds-ring 2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+        border-color: #fff transparent transparent transparent;
+    }
+    .lds-ring div:nth-child(1) {
+        animation-delay: -0.45s;
+    }
+    .lds-ring div:nth-child(2) {
+        animation-delay: -0.3s;
+    }
+    .lds-ring div:nth-child(3) {
+        animation-delay: -0.15s;
+    }
+    @keyframes lds-ring {
+        0% {
+            transform: rotate(0deg);
+        }
+        100% {
+            transform: rotate(360deg);
+        }
+    }
+  </style>
+</head>
+<body>
+  <div class="wrapper">
+    <div class="lds-ring">
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
     </div>
-
-    <script>
-      // You can also require other files to run in this process
-      require('./renderer.js');
-    </script>
-  </body>
+  </div>
+</body>
 </html>


### PR DESCRIPTION
Make loading screen less depressing
Create error screen that is displayed whenever http code is >=400
Minimised client on MacOS may now actually be reopened
Cmd+Q is now functional on MacOS and closes the app is pressed twice in 3 seconds